### PR TITLE
ubuntu 20.04: add libssl1.1

### DIFF
--- a/Configs/Ubuntu_20_04.json
+++ b/Configs/Ubuntu_20_04.json
@@ -144,6 +144,8 @@
 		"libnspr4",
 		"python3",
 		"python3-apt",
+		"libssl1.1",
+		"libssl1.1:i386",
 		"libssl3",
 		"libssl3:i386",
 		"curl",


### PR DESCRIPTION
Add libssl1.1 to the ubuntu20.04 image as still a lot of applications depend on this:

https://packages.ubuntu.com/focal/libssl1.1