### PR TITLE
Configs/Arch.json: update bootstrap tarball extension

### DIFF
--- a/Configs/Arch.json
+++ b/Configs/Arch.json
@@ -2,7 +2,7 @@
   "ImageName" : "ArchLinux",
   "Guest_SHA256Sums" : "https://geo.mirror.pkgbuild.com/iso/latest/sha256sums.txt",
   "Guest_BaseURL" : "https://geo.mirror.pkgbuild.com/iso/latest/",
-  "Guest_Image"   : "archlinux-bootstrap-x86_64.tar.gz",
+  "Guest_Image"   : "archlinux-bootstrap-x86_64.tar.zst",
 
   "Host_SHA256Sums" : "https://cloud-images.ubuntu.com/releases/focal/release/SHA256SUMS",
   "Host_BaseURL" : "https://cloud-images.ubuntu.com/releases/focal/release/",


### PR DESCRIPTION
Starting with the 2024.05.01 release, the Arch Linux bootstrap tarball uses zstd compression.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/130