### PR TITLE
Ubuntu_24_04: Seed additional mesa and pulseaudio libraries

### DIFF
--- a/Scripts/Ubuntu_24_04/build_install_mesa.sh
+++ b/Scripts/Ubuntu_24_04/build_install_mesa.sh
@@ -17,5 +17,5 @@ add-apt-repository -y ppa:kisak/kisak-mesa
 apt-get update
 apt-get upgrade -y
 apt-get install -y mesa-va-drivers mesa-vdpau-drivers mesa-vulkan-drivers libglx-mesa0 libgles2-mesa libgl1-mesa-glx libgl1-mesa-dri libegl1-mesa \
-    libegl-mesa0
+    libegl-mesa0 pulseaudio libgles1 libgles21 mesa-utils mesa-utils-extra libgl1
 apt-get upgrade -y


### PR DESCRIPTION
Since (at least) pulseaudio is required for sound to work in some games, this should ideally be part of the default rootfs, along with other recommended libraries.