### PR TITLE
Updated chroot.py to support additional args to be passed in; this is…

### DIFF
--- a/Scripts/chroot.py
+++ b/Scripts/chroot.py
@@ -623,8 +623,11 @@ def main():
         if IsArm:
             ChrootArgs.append("/fex/bin/FEX")
 
-        ChrootArgs.append(os.environ['SHELL'])
-        ChrootArgs.append("-i")
+        if len(sys.argv) > 2: 
+            ChrootArgs.extend(sys.argv[2:])
+        else:
+            ChrootArgs.append(os.environ['SHELL'])
+            ChrootArgs.append("-i")
         Result = subprocess.run(ChrootArgs)
 
         logging.info("Returning from chroot")


### PR DESCRIPTION
… useful because we can pass in commands to be run

e.g. ./chroot.py chroot /bin/bash -c "dpkg --add-architecture i386 && apt-get update && apt upgrade -y && apt install -y vulkan-tools libgl1-mesa-dri mesa-vulkan-drivers libglx-mesa0:i386 mesa-vulkan-drivers:i386 libgl1-mesa-dri:i386"
